### PR TITLE
Added Categorical Comparison Feature Extractor with tests

### DIFF
--- a/src/main/scala/edu/cmu/ml/rtw/pra/features/FeatureExtractor.scala
+++ b/src/main/scala/edu/cmu/ml/rtw/pra/features/FeatureExtractor.scala
@@ -41,3 +41,14 @@ class OneSidedFeatureExtractor(val edgeDict: Dictionary, val nodeDict: Dictionar
     }).toList.asJava
   }
 }
+
+class CategoricalComparisonFeatureExtractor(val edgeDict: Dictionary, val nodeDict: Dictionary) extends FeatureExtractor{
+  override def extractFeatures(source: Int, target: Int, subgraph: Subgraph) = {
+    subgraph.asScala.flatMap(entry => {
+      val path = entry._1.encodeAsHumanReadableString(edgeDict)
+      val (src, targ) = entry._2.asScala.partition(nodePair => nodePair.getLeft == source)
+      val pairs = for (int1 <- src; int2 <- targ) yield (nodeDict.getString(int1.getRight), nodeDict.getString(int2.getRight));
+      for{pair <- pairs}  yield s"CATCOMP:${path}:${pair._1}:${pair._2}"     
+    }).toList.asJava
+  }
+}

--- a/src/main/scala/edu/cmu/ml/rtw/pra/features/SubgraphFeatureGenerator.scala
+++ b/src/main/scala/edu/cmu/ml/rtw/pra/features/SubgraphFeatureGenerator.scala
@@ -108,6 +108,7 @@ class SubgraphFeatureGenerator(
     extractorNames.map(_ match {
       case "PraFeatureExtractor" => new PraFeatureExtractor(config.edgeDict)
       case "OneSidedFeatureExtractor" => new OneSidedFeatureExtractor(config.edgeDict, config.nodeDict)
+      case "CategoricalComparisonFeatureExtractor" => new CategoricalComparisonFeatureExtractor(config.edgeDict, config.nodeDict)
       case other => throw new IllegalStateException(s"Unrecognized feature extractor: $other")
     })
   }

--- a/src/test/scala/edu/cmu/ml/rtw/pra/features/FeatureExtractorSpec.scala
+++ b/src/test/scala/edu/cmu/ml/rtw/pra/features/FeatureExtractorSpec.scala
@@ -63,4 +63,15 @@ class FeatureExtractorSpec extends FlatSpecLike with Matchers {
     features should contain("TARGET:-rel1-:node3")
     features should contain("SOURCE:-rel2-:node3")
   }
+  
+  "CategoricalComparisonFeatureExtractor" should "extract categorical comparison features" in {
+    val pathTypes = Seq("-1-", "-2-")
+    val nodePairs = Seq(Set((1,2)), Set((1,3),(2,4)))
+    val extractor = new CategoricalComparisonFeatureExtractor(edgeDict, nodeDict)
+    val features = extractor.extractFeatures(1, 2, getSubgraph(pathTypes, nodePairs)).asScala
+    for {s <- features}  println(s)
+    features.size should be(1)
+    features should contain("CATCOMP:-rel2-:node3:node4")
+  }
+
 }


### PR DESCRIPTION
Feature format : CATCOMP:-rel1-:<intermediate1>:<intermediate2>
In experiment run, only pra_01 extracts features of this type whereas pra_02 doesn't.
